### PR TITLE
It's OK if truncate fails

### DIFF
--- a/iblocksync.py
+++ b/iblocksync.py
@@ -419,7 +419,10 @@ class ReceiveRemote(Remote):
                 remoteBlock = self._readBlock()
                 self.image.write(remoteBlock)
 
-        self.image.truncate()
+        try:
+            self.image.truncate()
+        except:
+            pass
         self.image.flush()
 
         self._sendEndOfTransmission()


### PR DESCRIPTION
Hi, and thanks for creating this great tool!
This is perhaps a lousy patch, which just solves it for me. I'm copying onto NBD virtual disk.
I guess you may want to propagate some exception and not others, maybe display a warning in any case?
Feel free to edit it as you like or let me know on which condition you'd merge it.

```
$ iblocksync/iblocksync ssh://root@host//dev/sda /dev/nbd0
Start syncing 19,532 of 19,532 blocks...
19,532 / 19,532 of 19,532 blocks processed; 331.77 blocks/s
Processed 19,532 source blocks in 65 seconds (301.07 blocks/s)
Processed 19,532 target blocks in 55 seconds (356.03 blocks/s)
Start transmitting 12,733 of 19,532 blocks (12.43 GiB)...
Traceback (most recent call last):d; 4.23 MiB/s
 File "iblocksync/iblocksync-receive", line 26, in <module>
   receiver.run(sourceImageInfo)
 File "iblocksync/iblocksync.py", line 422, in run
   self.image.truncate()
 File "iblocksync/iblocksync.py", line 266, in truncate
   self._file.truncate()
OSError: [Errno 22] Invalid argument
Traceback (most recent call last):
 File "iblocksync/iblocksync", line 114, in <module>
   receiver.readEndOfTransmission()
 File "iblocksync/iblocksync.py", line 632, in readEndOfTransmission
   raise ValueError("Expecting EOT signal ({!r}), got {!r}".format(_SIGNAL_EOT, signal))
ValueError: Expecting EOT signal (b'\x04'), got b''
```